### PR TITLE
Adicionar remoção de subvolumes (Closes #1)

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -39,12 +39,12 @@ checkDocker()
 
 cleanDocker()
 {
-    #docker rm -f $(docker ps -qa) && docker rmi $(docker images -f "dangling=true" -q)
-    if [ $(docker info 2>/dev/null | sed '/btrfs/!d' | grep -c "btrfs" ) = 0 ];
+    if [ $(docker info 2>/dev/null | sed '/btrfs/!d' | grep -c "btrfs") = 1 ];
     then
-        echo "ok"
+        docker rm -f $(docker ps -qa) && docker rmi $(docker images -q)
+        for i in "/var/lib/docker/btrfs/subvolumes/*"; do btrfs subvolume delete $i; done;
     else
-        echo "deu ruim"
+        docker rm -f $(docker ps -qa) && docker rmi $(docker images -f "dangling=true" -q)
     fi
     return
 


### PR DESCRIPTION
- Se o driver usado for btrfs, remover os subvolumes em /var/lib/docker/btrfs/subvolumes/*

Precisei remover o `-f "dangling=true"`, pois:

```
docker rm -f $(docker ps -qa) && docker rmi $(docker images -f "dangling=true" -q)
```

não removeria todas as imagens ao passo que:

```
btrfs subvolume delete $i
```

removeria todos os subvolumes.
